### PR TITLE
Start using ConcurrentDictionary  in the query cache

### DIFF
--- a/src/DbReader.Tests/IntegrationTests.cs
+++ b/src/DbReader.Tests/IntegrationTests.cs
@@ -73,6 +73,18 @@
             }
         }
 
+        public async Task ShouldHandleRunningInParallel()
+        {
+            var task1 = ShouldReadCustomersAndOrdersAsync();
+            var task2 = ShouldReadCustomersAndOrdersAsync();
+            var task3 = ShouldReadCustomersAndOrdersAsync();
+            var task4 = ShouldReadCustomersAndOrdersAsync();
+
+            await Task.WhenAll(task1, task2, task3, task4);
+        }
+
+
+
         public async Task ShouldReadCustomersAsync()
         {
             using (var connection = CreateConnection())
@@ -89,6 +101,17 @@
             using (var connection = CreateConnection())
             {
                 var customers = connection.Read<CustomerWithOrders>(SQL.CustomersAndOrders);
+                customers.Count().ShouldBe(89);
+                customers.SelectMany(c => c.Orders).Count().ShouldBe(830);
+            }
+        }
+
+        public async Task ShouldReadCustomersAndOrdersAsync()
+        {
+            using (var connection = CreateConnection())
+            {
+                await Task.Delay(10);
+                var customers = await connection.ReadAsync<CustomerWithOrders>(SQL.CustomersAndOrders);
                 customers.Count().ShouldBe(89);
                 customers.SelectMany(c => c.Orders).Count().ShouldBe(830);
             }

--- a/src/DbReader/DbReader.csproj
+++ b/src/DbReader/DbReader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
       <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-      <Version>2.0.1</Version>
+      <Version>2.0.2</Version>
       <Authors>Bernhard Richter</Authors>
       <PackageProjectUrl>https://github.com/seesharper/DbReader</PackageProjectUrl>
       <RepositoryType>git</RepositoryType>

--- a/src/DbReader/Readers/CachedInstanceReader.cs
+++ b/src/DbReader/Readers/CachedInstanceReader.cs
@@ -19,7 +19,7 @@ namespace DbReader.Readers
 
         private readonly IOneToManyMethodBuilder<T> oneToManyMethodBuilder;
         
-        private readonly Dictionary<IStructuralEquatable, T> queryCache = new Dictionary<IStructuralEquatable, T>(); 
+        private readonly ConcurrentDictionary<IStructuralEquatable, T> queryCache = new ConcurrentDictionary<IStructuralEquatable, T>(); 
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CachedInstanceReader{T}"/> class.
@@ -60,7 +60,7 @@ namespace DbReader.Readers
             if (!queryCache.TryGetValue(key, out instance))
             {
                 instance = instanceReader.Read(dataRecord, currentPrefix);
-                queryCache.Add(key, instance);
+                queryCache.TryAdd(key, instance);
             }
             return instance;
             


### PR DESCRIPTION
This PR fixes concurrency problems related to the query cache.