### PR TITLE
Fixed casing for list parameter regex

### DIFF
--- a/src/DbReader.Tests/RegExParameterParserTests.cs
+++ b/src/DbReader.Tests/RegExParameterParserTests.cs
@@ -49,6 +49,7 @@
         [InlineData("Id = @Parameter, AnotherId IN ( @ListParameter )")]
         [InlineData("Id = @Parameter, AnotherId IN(@ListParameter)")]
         [InlineData("Id = @Parameter, AnotherId IN( @ListParameter )")]
+        [InlineData("Id = @Parameter, AnotherId in( @ListParameter )")]
         public void ShouldMarkSingleListParameter(string source)
         {
             var parameters = parameterParser.GetParameters(source);

--- a/src/DbReader/Database/RegExParameterParser.cs
+++ b/src/DbReader/Database/RegExParameterParser.cs
@@ -28,7 +28,7 @@
         public RegExParameterParser(string parameterPattern, string listParameterPattern)
         {
             this.parameterMatcher = new Regex(parameterPattern, RegexOptions.Compiled);
-            this.listParameterMatcher = new Regex(listParameterPattern, RegexOptions.Compiled);
+            this.listParameterMatcher = new Regex(listParameterPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
 
         /// <summary>

--- a/src/DbReader/DbReader.csproj
+++ b/src/DbReader/DbReader.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;net462</TargetFrameworks>
     <!-- <TargetFramework>netcoreapp2.0</TargetFramework> -->
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://github.com/seesharper/DbReader</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Fixes a bug where the regular expression for finding list parameter did not perform a incase-sensitive option. 