### PR TITLE
Mark LightInject.Source as private asset

### DIFF
--- a/build/.vscode/launch.json
+++ b/build/.vscode/launch.json
@@ -1,18 +1,17 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": ".NET Script Debug",
-            "type": "coreclr",
-            "request": "launch",
-            "program": "dotnet",
-            "args": [
-              "exec", 
-              "/Users/bernhardrichter/.dotnet/tools/.store/dotnet-script/0.28.0/dotnet-script/0.28.0/tools/netcoreapp2.1/any/dotnet-script.dll"
-              "${file}"
-            ],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": true
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Script Debug",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${env:HOME}/.dotnet/tools/dotnet-script",
+      "args": ["${file}"],
+      "windows": {
+        "program": "${env:USERPROFILE}/.dotnet/tools/dotnet-script.exe",
+      },
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": true,
+    }
+  ]
 }

--- a/src/DbReader/DbReader.csproj
+++ b/src/DbReader/DbReader.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;net462</TargetFrameworks>
     <!-- <TargetFramework>netcoreapp2.0</TargetFramework> -->
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://github.com/seesharper/DbReader</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
@@ -29,7 +29,10 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LightInject.Source" Version="5.4.0" />
+    <PackageReference Include="LightInject.Source" Version="5.4.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net462'">


### PR DESCRIPTION
This PR marks `LightInject.Source` as a private assets so that it does not show up as a dependency on NuGet