### PR TITLE
Handle null for scalar values

### DIFF
--- a/src/DbReader.Tests/IntegrationTests.cs
+++ b/src/DbReader.Tests/IntegrationTests.cs
@@ -355,6 +355,18 @@ namespace DbReader.Tests
         }
 
         [Fact]
+        public async Task ShouldHandleNullScalarValueUsingValueConverter()
+        {
+            DbReaderOptions.WhenReading<CustomScalarValue?>().Use((datarecord, i) => new CustomScalarValue(datarecord.GetInt64(i)));
+            using (var connection = CreateConnection())
+            {
+                var scalar = await connection.ExecuteScalarAsync<CustomScalarValue?>("SELECT NULL FROM Customers WHERE CustomerID = 'ALFKI'");
+                scalar.ShouldBe(null);
+            }
+        }
+
+
+        [Fact]
         public async Task ShouldGetScalarValueAsync()
         {
             using (var connection = CreateConnection())

--- a/src/DbReader/DbConnectionExtensions.cs
+++ b/src/DbReader/DbConnectionExtensions.cs
@@ -240,7 +240,7 @@ namespace DbReader
 
         private static T ReadScalarValue<T>(IDataReader reader)
         {
-            if (!reader.Read())
+            if (!reader.Read() || reader.IsDBNull(0))
             {
                 return default(T);
             }

--- a/src/DbReader/DbReader.csproj
+++ b/src/DbReader/DbReader.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netstandard2.0;net462</TargetFrameworks>
     <!-- <TargetFramework>netcoreapp2.0</TargetFramework> -->
-    <Version>2.3.2</Version>
+    <Version>2.3.3</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://github.com/seesharper/DbReader</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
This PR fixes a bug when executing `ExecuteScalar` and the result set contains a `null` value,