### PR TITLE
Bugfix caching 

### DIFF
--- a/src/DbReader.Tests/IntegrationTests.cs
+++ b/src/DbReader.Tests/IntegrationTests.cs
@@ -515,13 +515,13 @@ namespace DbReader.Tests
                 {
                     var customers = await connection.ReadAsync<CustomerWithOrders>("SELECT c.CustomerID as CustomerWithOrdersId, o.OrderId as O_OrderId, o.OrderDate as O_OrderDate FROM Customers c INNER JOIN Orders o ON c.CustomerId =o.CustomerId AND c.CustomerId = @CustomerId", new { CustomerId = "ALFKI" });
                     var firstCustomer = customers.First();
+                    var orderDate = new DateTime(2020, 11, 18);
                     var firstCustomerId = firstCustomer.CustomerWithOrdersId;
-                    int rowsAffected = await connection.ExecuteAsync("UPDATE Orders set OrderDate = @OrderDate WHERE CustomerID =@CustomerId", new { OrderDate = DateTime.Now, CustomerId = firstCustomerId });
+                    int rowsAffected = await connection.ExecuteAsync("UPDATE Orders set OrderDate = @OrderDate WHERE CustomerID =@CustomerId", new { OrderDate = orderDate, CustomerId = firstCustomerId });
                     customers = await connection.ReadAsync<CustomerWithOrders>("SELECT c.CustomerID as CustomerWithOrdersId, o.OrderId as O_OrderId, o.OrderDate as O_OrderDate FROM Customers c INNER JOIN Orders o ON c.CustomerId =o.CustomerId AND c.CustomerId = @CustomerId", new { CustomerId = "ALFKI" });
-                    var test = connection.ExecuteScalar<DateTime>("SELECT OrderDate FROM Orders WHERE CustomerID = @CustomerId", new { CustomerId = firstCustomerId });
+                    customers.Single().Orders.ShouldAllBe(o => o.OrderDate == orderDate);
                     transaction.Rollback();
                 }
-
             }
         }
 

--- a/src/DbReader.Tests/QueryCacheTests.cs
+++ b/src/DbReader.Tests/QueryCacheTests.cs
@@ -14,8 +14,8 @@ namespace DbReader.Tests
         {
             var rows = new[]
             {
-                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 10" },
-                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 20" }
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 10" },
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 20" }
             };
             var dataReader = rows.ToDataReader();
 
@@ -23,8 +23,8 @@ namespace DbReader.Tests
 
             rows = new[]
             {
-                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 30" },
-                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 30" }
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 30" },
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 30" }
             };
 
             dataReader = rows.ToDataReader();
@@ -64,7 +64,7 @@ namespace DbReader.Tests
         public class CustomerWithOrders
         {
             [Key]
-            public string CustomerId { get; set; }
+            public string CustomerWithOrdersId { get; set; }
 
             public string Name { get; set; }
             public ICollection<Order> Orders { get; set; }

--- a/src/DbReader.Tests/QueryCacheTests.cs
+++ b/src/DbReader.Tests/QueryCacheTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+using Shouldly;
+using System.Linq;
+
+namespace DbReader.Tests
+{
+    public class QueryCacheTests
+    {
+
+        [Fact]
+        public void ShouldNotCacheAcrossReadsUsingOneToManyRelation()
+        {
+            var rows = new[]
+            {
+                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 10" },
+                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 20" }
+            };
+            var dataReader = rows.ToDataReader();
+
+            var customers = dataReader.Read<CustomerWithOrders>();
+
+            rows = new[]
+            {
+                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 30" },
+                new { CustomerId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 30" }
+            };
+
+            dataReader = rows.ToDataReader();
+
+            customers = dataReader.Read<CustomerWithOrders>();
+
+            customers.Single().Orders.ShouldAllBe(o => o.ShippingAddress == "John Dear Road 30");
+        }
+
+        [Fact]
+        public void ShouldNotCacheAcrossReadsUsingManyToOneRelation()
+        {
+            var rows = new[]
+            {
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Alfreds Futterkiste" , OrderWithCustomerId = 1 ,ShippingAddress = "John Dear Road 10" },
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Alfreds Futterkiste" , OrderWithCustomerId = 2 ,ShippingAddress = "John Dear Road 20" }
+            };
+            var dataReader = rows.ToDataReader();
+
+            dataReader.Read<OrderWithCustomer>();
+
+            rows = new[]
+             {
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Fred Futterkiste" , OrderWithCustomerId = 1 ,ShippingAddress = "John Dear Road 10" },
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Fred Futterkiste" , OrderWithCustomerId = 2 ,ShippingAddress = "John Dear Road 20" }
+            };
+
+            dataReader = rows.ToDataReader();
+
+            var orders = dataReader.Read<OrderWithCustomer>();
+
+            orders.First().Customer.Name.ShouldBe("Fred Futterkiste");
+        }
+
+
+
+        public class CustomerWithOrders
+        {
+            [Key]
+            public string CustomerId { get; set; }
+
+            public string Name { get; set; }
+            public ICollection<Order> Orders { get; set; }
+        }
+
+
+        public class Order
+        {
+            [Key]
+            public int OrderId { get; set; }
+
+            public string ShippingAddress { get; set; }
+        }
+
+        public class Customer
+        {
+            [Key]
+            public string CustomerId { get; set; }
+
+            public string Name { get; set; }
+
+        }
+
+        public class OrderWithCustomer
+        {
+            [Key]
+            public int OrderWithCustomerId { get; set; }
+
+            public Customer Customer { get; set; }
+        }
+
+    }
+
+
+
+}

--- a/src/DbReader.Tests/QueryCacheTests.cs
+++ b/src/DbReader.Tests/QueryCacheTests.cs
@@ -8,30 +8,29 @@ namespace DbReader.Tests
 {
     public class QueryCacheTests
     {
-
         [Fact]
         public void ShouldNotCacheAcrossReadsUsingOneToManyRelation()
         {
             var rows = new[]
             {
-                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 10" },
-                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 20" }
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "Address 1" },
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "Address 2" }
             };
             var dataReader = rows.ToDataReader();
-
+            SqlStatement.Current = "TEST-STATEMENT";
             var customers = dataReader.Read<CustomerWithOrders>();
 
             rows = new[]
             {
-                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "John Dear Road 30" },
-                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "John Dear Road 30" }
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 1 ,Orders_ShippingAddress = "Address 3" },
+                new { CustomerWithOrdersId = "ALFKI", Name = "Alfreds Futterkiste" , Orders_OrderId = 2 ,Orders_ShippingAddress = "Address 3" }
             };
 
             dataReader = rows.ToDataReader();
-
+            SqlStatement.Current = "TEST-STATEMENT";
             customers = dataReader.Read<CustomerWithOrders>();
 
-            customers.Single().Orders.ShouldAllBe(o => o.ShippingAddress == "John Dear Road 30");
+            customers.Single().Orders.ShouldAllBe(o => o.ShippingAddress == "Address 3");
         }
 
         [Fact]
@@ -39,21 +38,21 @@ namespace DbReader.Tests
         {
             var rows = new[]
             {
-                new { Customer_CustomerId = "ALFKI", Customer_Name = "Alfreds Futterkiste" , OrderWithCustomerId = 1 ,ShippingAddress = "John Dear Road 10" },
-                new { Customer_CustomerId = "ALFKI", Customer_Name = "Alfreds Futterkiste" , OrderWithCustomerId = 2 ,ShippingAddress = "John Dear Road 20" }
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Alfreds Futterkiste" , OrderWithCustomerId = 1 ,ShippingAddress = "Address 1" },
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Alfreds Futterkiste" , OrderWithCustomerId = 2 ,ShippingAddress = "Address 2" }
             };
             var dataReader = rows.ToDataReader();
-
+            SqlStatement.Current = "TEST-STATEMENT";
             dataReader.Read<OrderWithCustomer>();
 
             rows = new[]
              {
-                new { Customer_CustomerId = "ALFKI", Customer_Name = "Fred Futterkiste" , OrderWithCustomerId = 1 ,ShippingAddress = "John Dear Road 10" },
-                new { Customer_CustomerId = "ALFKI", Customer_Name = "Fred Futterkiste" , OrderWithCustomerId = 2 ,ShippingAddress = "John Dear Road 20" }
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Fred Futterkiste" , OrderWithCustomerId = 1 ,ShippingAddress = "Address 1" },
+                new { Customer_CustomerId = "ALFKI", Customer_Name = "Fred Futterkiste" , OrderWithCustomerId = 2 ,ShippingAddress = "Address 2" }
             };
 
             dataReader = rows.ToDataReader();
-
+            SqlStatement.Current = "TEST-STATEMENT";
             var orders = dataReader.Read<OrderWithCustomer>();
 
             orders.First().Customer.Name.ShouldBe("Fred Futterkiste");
@@ -95,9 +94,5 @@ namespace DbReader.Tests
 
             public Customer Customer { get; set; }
         }
-
     }
-
-
-
 }

--- a/src/DbReader/CompositionRoot.cs
+++ b/src/DbReader/CompositionRoot.cs
@@ -76,7 +76,7 @@
                 .Register<IPrefixResolver, PrefixResolver>(new PerScopeLifetime())
 
                 .Register<IInstanceReaderFactory>(f => new InstanceReaderFactory(f.GetInstance), new PerScopeLifetime())
-                .Register<IGenericInstanceReaderFactory>(f => new GenericInstanceReaderFactory(f.GetInstance), new PerScopeLifetime())
+                .Register<IGenericInstanceReaderFactory>(f => new GenericInstanceReaderFactory(f), new PerScopeLifetime())
 
                 //.Register(typeof(IInstanceReader<>), typeof(InstanceReader<>))
                 .Register(typeof(IInstanceReader<>), typeof(InstanceReader<>), new PerScopeLifetime())

--- a/src/DbReader/CompositionRoot.cs
+++ b/src/DbReader/CompositionRoot.cs
@@ -75,8 +75,8 @@
 
                 .Register<IPrefixResolver, PrefixResolver>(new PerScopeLifetime())
 
-                .Register<IInstanceReaderFactory>(f => new InstanceReaderFactory(f.GetInstance), new PerScopeLifetime())
-                .Register<IGenericInstanceReaderFactory>(f => new GenericInstanceReaderFactory(f), new PerScopeLifetime())
+                //.Register<IInstanceReaderFactory>(f => new InstanceReaderFactory(f.GetInstance), new PerScopeLifetime())
+                .Register<IInstanceReaderFactory>(f => new InstanceReaderFactory(f), new PerScopeLifetime())
 
                 //.Register(typeof(IInstanceReader<>), typeof(InstanceReader<>))
                 .Register(typeof(IInstanceReader<>), typeof(InstanceReader<>), new PerScopeLifetime())

--- a/src/DbReader/CompositionRoot.cs
+++ b/src/DbReader/CompositionRoot.cs
@@ -76,6 +76,7 @@
                 .Register<IPrefixResolver, PrefixResolver>(new PerScopeLifetime())
 
                 .Register<IInstanceReaderFactory>(f => new InstanceReaderFactory(f.GetInstance), new PerScopeLifetime())
+                .Register<IGenericInstanceReaderFactory>(f => new GenericInstanceReaderFactory(f.GetInstance), new PerScopeLifetime())
 
                 //.Register(typeof(IInstanceReader<>), typeof(InstanceReader<>))
                 .Register(typeof(IInstanceReader<>), typeof(InstanceReader<>), new PerScopeLifetime())

--- a/src/DbReader/Construction/CachedInstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Construction/CachedInstanceReaderMethodBuilder.cs
@@ -2,10 +2,11 @@
 {
     using System;
     using System.Data;
+    using DbReader.Readers;
     using Interfaces;
 
     /// <summary>
-    /// An <see cref="IInstanceReaderMethodBuilder{T}"/> decorator that is used 
+    /// An <see cref="IInstanceReaderMethodBuilder{T}"/> decorator that is used
     /// to cache the dynamic method created at runtime to read an instance of type <typeparamref name="T"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
@@ -30,9 +31,9 @@
         /// <param name="prefix">The current prefix.</param>
         /// <returns>A method that creates an instance of <typeparamref name="T"/>
         /// based on the given <paramref name="dataRecord"/>.</returns>
-        public Func<IDataRecord, T> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Func<IDataRecord, IGenericInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix)
         {
-            return StaticCache<Func<IDataRecord, T>>.GetOrAdd(typeof(T), prefix,
+            return StaticCache<Func<IDataRecord, IGenericInstanceReaderFactory, T>>.GetOrAdd(typeof(T), prefix,
                 () => instanceReaderMethodBuilder.Value.CreateMethod(dataRecord, prefix));
         }
     }

--- a/src/DbReader/Construction/CachedInstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Construction/CachedInstanceReaderMethodBuilder.cs
@@ -31,9 +31,9 @@
         /// <param name="prefix">The current prefix.</param>
         /// <returns>A method that creates an instance of <typeparamref name="T"/>
         /// based on the given <paramref name="dataRecord"/>.</returns>
-        public Func<IDataRecord, IGenericInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Func<IDataRecord, IInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix)
         {
-            return StaticCache<Func<IDataRecord, IGenericInstanceReaderFactory, T>>.GetOrAdd(typeof(T), prefix,
+            return StaticCache<Func<IDataRecord, IInstanceReaderFactory, T>>.GetOrAdd(typeof(T), prefix,
                 () => instanceReaderMethodBuilder.Value.CreateMethod(dataRecord, prefix));
         }
     }

--- a/src/DbReader/Construction/CachedOneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/CachedOneToManyMethodBuilder.cs
@@ -29,9 +29,9 @@ namespace DbReader.Construction
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        public Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
         {
-            return StaticCache<Action<IDataRecord, T, IGenericInstanceReaderFactory>>.GetOrAdd(typeof(T), prefix,
+            return StaticCache<Action<T, IDataRecord, IGenericInstanceReaderFactory>>.GetOrAdd(typeof(T), prefix,
                 () => oneToManyMethodBuilder.CreateMethod(dataRecord, prefix));
         }
     }

--- a/src/DbReader/Construction/CachedOneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/CachedOneToManyMethodBuilder.cs
@@ -2,24 +2,25 @@ namespace DbReader.Construction
 {
     using System;
     using System.Data;
+    using DbReader.Readers;
 
     /// <summary>
-    /// An <see cref="IOneToManyMethodBuilder{T}"/> decorator that 
+    /// An <see cref="IOneToManyMethodBuilder{T}"/> decorator that
     /// caches the dynamically created method used to populate collection
     /// properties of a given type.
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> for which to create the dynamic method.</typeparam>
     public class CachedOneToManyMethodBuilder<T> : IOneToManyMethodBuilder<T>
-    {      
-        private readonly IOneToManyMethodBuilder<T> oneToManyMethodBuilder;        
-        
+    {
+        private readonly IOneToManyMethodBuilder<T> oneToManyMethodBuilder;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CachedOneToManyMethodBuilder{T}"/> class.
         /// </summary>
         /// <param name="oneToManyMethodBuilder">The target <see cref="IOneToManyMethodBuilder{T}"/>.</param>
         public CachedOneToManyMethodBuilder(IOneToManyMethodBuilder<T> oneToManyMethodBuilder)
         {
-            this.oneToManyMethodBuilder = oneToManyMethodBuilder;       
+            this.oneToManyMethodBuilder = oneToManyMethodBuilder;
         }
 
         /// <summary>
@@ -28,9 +29,9 @@ namespace DbReader.Construction
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        public Action<IDataRecord, T> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
         {
-            return StaticCache<Action<IDataRecord, T>>.GetOrAdd(typeof (T), prefix,
+            return StaticCache<Action<IDataRecord, T, IGenericInstanceReaderFactory>>.GetOrAdd(typeof(T), prefix,
                 () => oneToManyMethodBuilder.CreateMethod(dataRecord, prefix));
         }
     }

--- a/src/DbReader/Construction/CachedOneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/CachedOneToManyMethodBuilder.cs
@@ -29,9 +29,9 @@ namespace DbReader.Construction
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        public Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Action<T, IDataRecord, IInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
         {
-            return StaticCache<Action<T, IDataRecord, IGenericInstanceReaderFactory>>.GetOrAdd(typeof(T), prefix,
+            return StaticCache<Action<T, IDataRecord, IInstanceReaderFactory>>.GetOrAdd(typeof(T), prefix,
                 () => oneToManyMethodBuilder.CreateMethod(dataRecord, prefix));
         }
     }

--- a/src/DbReader/Construction/IManyToOneMethodBuilder.cs
+++ b/src/DbReader/Construction/IManyToOneMethodBuilder.cs
@@ -2,9 +2,10 @@
 {
     using System;
     using System.Data;
+    using DbReader.Readers;
 
     /// <summary>
-    /// Represents a class that dynamically creates a method used to 
+    /// Represents a class that dynamically creates a method used to
     /// populate "many-to-one" properties of a given type.
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> for which to create the dynamic method.</typeparam>
@@ -16,6 +17,6 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped "many-to-one" properties.</returns>
-        Action<IDataRecord, T> CreateMethod(IDataRecord dataRecord, string prefix);
+        Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Construction/IManyToOneMethodBuilder.cs
+++ b/src/DbReader/Construction/IManyToOneMethodBuilder.cs
@@ -17,6 +17,6 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped "many-to-one" properties.</returns>
-        Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
+        Action<T, IDataRecord, IInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Construction/IManyToOneMethodBuilder.cs
+++ b/src/DbReader/Construction/IManyToOneMethodBuilder.cs
@@ -17,6 +17,6 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped "many-to-one" properties.</returns>
-        Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
+        Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Construction/IOneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/IOneToManyMethodBuilder.cs
@@ -17,6 +17,6 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
+        Action<T, IDataRecord, IInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Construction/IOneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/IOneToManyMethodBuilder.cs
@@ -2,9 +2,10 @@
 {
     using System;
     using System.Data;
+    using DbReader.Readers;
 
     /// <summary>
-    /// Represents a class that dynamically creates a method used to 
+    /// Represents a class that dynamically creates a method used to
     /// populate collection properties of a given type.
     /// </summary>
     /// <typeparam name="T">The <see cref="Type"/> for which to create the dynamic method.</typeparam>
@@ -16,6 +17,6 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        Action<IDataRecord, T> CreateMethod(IDataRecord dataRecord, string prefix);
+        Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Construction/IOneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/IOneToManyMethodBuilder.cs
@@ -17,6 +17,6 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
+        Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Construction/InstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Construction/InstanceReaderMethodBuilder.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Data;
+    using DbReader.Readers;
     using Interfaces;
     using Selectors;
 
@@ -39,24 +40,24 @@
         /// <param name="prefix">The current prefix.</param>
         /// <returns>A method that creates an instance of <typeparamref name="T"/>
         /// based on the given <paramref name="dataRecord"/>.</returns>
-        public Func<IDataRecord, T> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Func<IDataRecord, IGenericInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix)
         {
             int[] ordinals = ordinalSelector.Execute(typeof(T), dataRecord, prefix);
             Func<IDataRecord, int[], T> propertyReaderMethod = propertyReaderMethodBuilder.CreateMethod();
 
-            Action<IDataRecord, T> manyToOneMethod = manyToOneMethodBuilder.CreateMethod(dataRecord, prefix);
+            Action<IDataRecord, T, IGenericInstanceReaderFactory> manyToOneMethod = manyToOneMethodBuilder.CreateMethod(dataRecord, prefix);
 
             if (manyToOneMethod != null)
             {
-                return record =>
+                return (record, instanceReaderFactory) =>
                     {
                         var instance = propertyReaderMethod(record, ordinals);
-                        manyToOneMethod(record, instance);
+                        manyToOneMethod(record, instance, instanceReaderFactory);
                         return instance;
                     };
             }
 
-            return record => propertyReaderMethod(record, ordinals);
+            return (record, instanceReaderFactory) => propertyReaderMethod(record, ordinals);
         }
     }
 }

--- a/src/DbReader/Construction/InstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Construction/InstanceReaderMethodBuilder.cs
@@ -40,12 +40,12 @@
         /// <param name="prefix">The current prefix.</param>
         /// <returns>A method that creates an instance of <typeparamref name="T"/>
         /// based on the given <paramref name="dataRecord"/>.</returns>
-        public Func<IDataRecord, IGenericInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Func<IDataRecord, IInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix)
         {
             int[] ordinals = ordinalSelector.Execute(typeof(T), dataRecord, prefix);
             Func<IDataRecord, int[], T> propertyReaderMethod = propertyReaderMethodBuilder.CreateMethod();
 
-            Action<T, IDataRecord, IGenericInstanceReaderFactory> manyToOneMethod = manyToOneMethodBuilder.CreateMethod(dataRecord, prefix);
+            Action<T, IDataRecord, IInstanceReaderFactory> manyToOneMethod = manyToOneMethodBuilder.CreateMethod(dataRecord, prefix);
 
             if (manyToOneMethod != null)
             {

--- a/src/DbReader/Construction/InstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Construction/InstanceReaderMethodBuilder.cs
@@ -45,14 +45,14 @@
             int[] ordinals = ordinalSelector.Execute(typeof(T), dataRecord, prefix);
             Func<IDataRecord, int[], T> propertyReaderMethod = propertyReaderMethodBuilder.CreateMethod();
 
-            Action<IDataRecord, T, IGenericInstanceReaderFactory> manyToOneMethod = manyToOneMethodBuilder.CreateMethod(dataRecord, prefix);
+            Action<T, IDataRecord, IGenericInstanceReaderFactory> manyToOneMethod = manyToOneMethodBuilder.CreateMethod(dataRecord, prefix);
 
             if (manyToOneMethod != null)
             {
                 return (record, instanceReaderFactory) =>
                     {
                         var instance = propertyReaderMethod(record, ordinals);
-                        manyToOneMethod(record, instance, instanceReaderFactory);
+                        manyToOneMethod(instance, record, instanceReaderFactory);
                         return instance;
                     };
             }

--- a/src/DbReader/Construction/ManyToOneMethodBuilder.cs
+++ b/src/DbReader/Construction/ManyToOneMethodBuilder.cs
@@ -60,9 +60,6 @@
                 {
                     shouldCreateMethod = true;
                     Type instanceReaderType = typeof(IInstanceReader<>).MakeGenericType(property.PropertyType);
-                    // object instanceReader = instanceReaderFactory.GetInstanceReader(instanceReaderType, propertyPrefix);
-
-                    // instanceReaders.Add(instanceReader);
 
                     generator.Emit(OpCodes.Ldarg_0);
 

--- a/src/DbReader/Construction/ManyToOneMethodBuilder.cs
+++ b/src/DbReader/Construction/ManyToOneMethodBuilder.cs
@@ -19,7 +19,6 @@
     {
         private readonly IMethodSkeletonFactory methodSkeletonFactory;
         private readonly IPropertySelector manyToOnePropertySelector;
-        private readonly IInstanceReaderFactory instanceReaderFactory;
         private readonly IPrefixResolver prefixResolver;
 
         /// <summary>
@@ -27,13 +26,11 @@
         /// </summary>
         /// <param name="methodSkeletonFactory">The <see cref="IMethodSkeletonFactory"/> that is responsible for providing an <see cref="IMethodSkeleton"/> instance.</param>
         /// <param name="manyToOnePropertySelector">The <see cref="IPropertySelector"/> that is responsible for selecting properties that represents a "many-to-one" relationship.</param>
-        /// <param name="instanceReaderFactory">A factory delegate used to create <see cref="IInstanceReader{T}"/> instances for each "many-to-one" property.</param>
         /// <param name="prefixResolver">The <see cref="IPrefixResolver"/> that is responsible for resolving the prefix for each "many-to-one" property.</param>
-        public ManyToOneMethodBuilder(IMethodSkeletonFactory methodSkeletonFactory, IPropertySelector manyToOnePropertySelector, IInstanceReaderFactory instanceReaderFactory, IPrefixResolver prefixResolver)
+        public ManyToOneMethodBuilder(IMethodSkeletonFactory methodSkeletonFactory, IPropertySelector manyToOnePropertySelector, IPrefixResolver prefixResolver)
         {
             this.methodSkeletonFactory = methodSkeletonFactory;
             this.manyToOnePropertySelector = manyToOnePropertySelector;
-            this.instanceReaderFactory = instanceReaderFactory;
             this.prefixResolver = prefixResolver;
         }
 
@@ -43,7 +40,7 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped "many-to-one" properties.</returns>
-        public Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Action<T, IDataRecord, IInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
         {
             var properties = manyToOnePropertySelector.Execute(typeof(T));
             if (properties.Length == 0)
@@ -51,7 +48,7 @@
                 return null;
             }
             var instanceReaders = new List<object>(properties.Length);
-            var methodSkeleton = methodSkeletonFactory.GetMethodSkeleton("ManyToOneDynamicMethod", typeof(void), new[] { typeof(T), typeof(IDataRecord), typeof(IGenericInstanceReaderFactory) });
+            var methodSkeleton = methodSkeletonFactory.GetMethodSkeleton("ManyToOneDynamicMethod", typeof(void), new[] { typeof(T), typeof(IDataRecord), typeof(IInstanceReaderFactory) });
             var generator = methodSkeleton.GetGenerator();
 
             bool shouldCreateMethod = false;
@@ -72,7 +69,7 @@
 
                     // Push the instance readers
                     generator.Emit(OpCodes.Ldarg_2);
-                    var closedGenericGetInstanceReaderMethod = typeof(IGenericInstanceReaderFactory).GetMethod(nameof(IGenericInstanceReaderFactory.GetInstanceReader)).MakeGenericMethod(property.PropertyType);
+                    var closedGenericGetInstanceReaderMethod = typeof(IInstanceReaderFactory).GetMethod(nameof(IInstanceReaderFactory.GetInstanceReader)).MakeGenericMethod(property.PropertyType);
                     generator.Emit(OpCodes.Ldstr, propertyPrefix);
                     generator.Emit(OpCodes.Callvirt, closedGenericGetInstanceReaderMethod);
 
@@ -92,7 +89,7 @@
             if (shouldCreateMethod)
             {
                 generator.Emit(OpCodes.Ret);
-                var method = (Action<T, IDataRecord, IGenericInstanceReaderFactory>)methodSkeleton.CreateDelegate(typeof(Action<T, IDataRecord, IGenericInstanceReaderFactory>));
+                var method = (Action<T, IDataRecord, IInstanceReaderFactory>)methodSkeleton.CreateDelegate(typeof(Action<T, IDataRecord, IInstanceReaderFactory>));
                 return method;
             }
 

--- a/src/DbReader/Construction/ManyToOneMethodBuilder.cs
+++ b/src/DbReader/Construction/ManyToOneMethodBuilder.cs
@@ -43,7 +43,7 @@
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped "many-to-one" properties.</returns>
-        public Action<IDataRecord, T, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
         {
             var properties = manyToOnePropertySelector.Execute(typeof(T));
             if (properties.Length == 0)
@@ -93,8 +93,7 @@
             {
                 generator.Emit(OpCodes.Ret);
                 var method = (Action<T, IDataRecord, IGenericInstanceReaderFactory>)methodSkeleton.CreateDelegate(typeof(Action<T, IDataRecord, IGenericInstanceReaderFactory>));
-
-                return (record, instance, instanceReaderFactory) => method(instance, record, instanceReaderFactory);
+                return method;
             }
 
             return null;

--- a/src/DbReader/Construction/OneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/OneToManyMethodBuilder.cs
@@ -95,8 +95,6 @@ namespace DbReader.Construction
                 generator.Emit(OpCodes.Ret);
                 var method = (Action<T, IDataRecord, IInstanceReaderFactory>)methodSkeleton.CreateDelegate(typeof(Action<T, IDataRecord, IInstanceReaderFactory>));
                 return method;
-                // // Note Change the signature to avoid another delegate
-                // return (record, instance, instanceReaderFactory) => method(instance, record, instanceReaderFactory);
             }
 
             return null;

--- a/src/DbReader/Construction/OneToManyMethodBuilder.cs
+++ b/src/DbReader/Construction/OneToManyMethodBuilder.cs
@@ -18,7 +18,6 @@ namespace DbReader.Construction
     {
         private readonly IMethodSkeletonFactory methodSkeletonFactory;
         private readonly IPropertySelector oneToManyPropertySelector;
-        private readonly IInstanceReaderFactory instanceReaderFactory;
         private readonly IPrefixResolver prefixResolver;
 
         /// <summary>
@@ -26,13 +25,11 @@ namespace DbReader.Construction
         /// </summary>
         /// <param name="methodSkeletonFactory">The <see cref="IMethodSkeletonFactory"/> that is responsible for providing an <see cref="IMethodSkeleton"/> instance.</param>
         /// <param name="oneToManyPropertySelector">The <see cref="IPropertySelector"/> that is responsible for selecting properties that represents a "one-to-many" relationship.</param>
-        /// <param name="instanceReaderFactory">A factory delegate used to create <see cref="IInstanceReader{T}"/> instances for each "one-to-many" property.</param>
         /// <param name="prefixResolver">The <see cref="IPrefixResolver"/> that is responsible for resolving the prefix for each "one-to-many" property.</param>
-        public OneToManyMethodBuilder(IMethodSkeletonFactory methodSkeletonFactory, IPropertySelector oneToManyPropertySelector, IInstanceReaderFactory instanceReaderFactory, IPrefixResolver prefixResolver)
+        public OneToManyMethodBuilder(IMethodSkeletonFactory methodSkeletonFactory, IPropertySelector oneToManyPropertySelector, IPrefixResolver prefixResolver)
         {
             this.methodSkeletonFactory = methodSkeletonFactory;
             this.oneToManyPropertySelector = oneToManyPropertySelector;
-            this.instanceReaderFactory = instanceReaderFactory;
             this.prefixResolver = prefixResolver;
         }
 
@@ -42,7 +39,7 @@ namespace DbReader.Construction
         /// <param name="dataRecord">The source <see cref="IDataRecord"/>.</param>
         /// <param name="prefix">The property prefix used to identify the fields in the <see cref="IDataRecord"/>.</param>
         /// <returns>A delegate representing a dynamic method that populates mapped collection properties.</returns>
-        public Action<T, IDataRecord, IGenericInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
+        public Action<T, IDataRecord, IInstanceReaderFactory> CreateMethod(IDataRecord dataRecord, string prefix)
         {
             PropertyInfo[] properties = oneToManyPropertySelector.Execute(typeof(T));
             if (properties.Length == 0)
@@ -50,7 +47,7 @@ namespace DbReader.Construction
                 return null;
             }
             var instanceReaders = new List<object>(properties.Length);
-            var methodSkeleton = methodSkeletonFactory.GetMethodSkeleton("OneToManyDynamicMethod", typeof(void), new[] { typeof(T), typeof(IDataRecord), typeof(IGenericInstanceReaderFactory) });
+            var methodSkeleton = methodSkeletonFactory.GetMethodSkeleton("OneToManyDynamicMethod", typeof(void), new[] { typeof(T), typeof(IDataRecord), typeof(IInstanceReaderFactory) });
             var generator = methodSkeleton.GetGenerator();
             bool shouldCreateMethod = false;
             foreach (var property in properties)
@@ -75,7 +72,7 @@ namespace DbReader.Construction
 
                     // Push the instancereader factory
                     generator.Emit(OpCodes.Ldarg_2);
-                    var closedGenericGetInstanceReaderMethod = typeof(IGenericInstanceReaderFactory).GetMethod(nameof(IGenericInstanceReaderFactory.GetInstanceReader)).MakeGenericMethod(elementType);
+                    var closedGenericGetInstanceReaderMethod = typeof(IInstanceReaderFactory).GetMethod(nameof(IInstanceReaderFactory.GetInstanceReader)).MakeGenericMethod(elementType);
                     generator.Emit(OpCodes.Ldstr, propertyPrefix);
                     generator.Emit(OpCodes.Callvirt, closedGenericGetInstanceReaderMethod);
 
@@ -96,7 +93,7 @@ namespace DbReader.Construction
             if (shouldCreateMethod)
             {
                 generator.Emit(OpCodes.Ret);
-                var method = (Action<T, IDataRecord, IGenericInstanceReaderFactory>)methodSkeleton.CreateDelegate(typeof(Action<T, IDataRecord, IGenericInstanceReaderFactory>));
+                var method = (Action<T, IDataRecord, IInstanceReaderFactory>)methodSkeleton.CreateDelegate(typeof(Action<T, IDataRecord, IInstanceReaderFactory>));
                 return method;
                 // // Note Change the signature to avoid another delegate
                 // return (record, instance, instanceReaderFactory) => method(instance, record, instanceReaderFactory);

--- a/src/DbReader/DbReader.csproj
+++ b/src/DbReader/DbReader.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0;net462</TargetFrameworks>
     <!-- <TargetFramework>netcoreapp2.0</TargetFramework> -->
-    <Version>2.3.6</Version>
+    <Version>2.3.7</Version>
     <Authors>Bernhard Richter</Authors>
     <PackageProjectUrl>https://github.com/seesharper/DbReader</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/DbReader/Interfaces/IInstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Interfaces/IInstanceReaderMethodBuilder.cs
@@ -19,6 +19,6 @@
         /// <param name="prefix">The current prefix.</param>
         /// <returns>A method that creates an instance of <typeparamref name="T"/>
         /// based on the given <paramref name="dataRecord"/>.</returns>
-        Func<IDataRecord, IGenericInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix);
+        Func<IDataRecord, IInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Interfaces/IInstanceReaderMethodBuilder.cs
+++ b/src/DbReader/Interfaces/IInstanceReaderMethodBuilder.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Data;
+    using DbReader.Readers;
 
     /// <summary>
     /// Represents a class that creates an instance of <typeparamref name="T"/>
@@ -18,6 +19,6 @@
         /// <param name="prefix">The current prefix.</param>
         /// <returns>A method that creates an instance of <typeparamref name="T"/>
         /// based on the given <paramref name="dataRecord"/>.</returns>
-        Func<IDataRecord, T> CreateMethod(IDataRecord dataRecord, string prefix);
+        Func<IDataRecord, IGenericInstanceReaderFactory, T> CreateMethod(IDataRecord dataRecord, string prefix);
     }
 }

--- a/src/DbReader/Readers/CachedInstanceReader.cs
+++ b/src/DbReader/Readers/CachedInstanceReader.cs
@@ -18,7 +18,7 @@ namespace DbReader.Readers
         private readonly IKeyReader keyReader;
 
         private readonly IOneToManyMethodBuilder<T> oneToManyMethodBuilder;
-
+        private readonly IGenericInstanceReaderFactory instanceReaderFactory;
         private readonly ConcurrentDictionary<IStructuralEquatable, T> queryCache = new ConcurrentDictionary<IStructuralEquatable, T>();
 
         /// <summary>
@@ -28,11 +28,12 @@ namespace DbReader.Readers
         /// for reading an instance of <typeparamref name="T"/> from an <see cref="IDataRecord"/>.</param>
         /// <param name="keyReader">An instance of <typeparamref name="T"/>.</param>
         /// <param name="oneToManyMethodBuilder"></param>
-        public CachedInstanceReader(IInstanceReader<T> instanceReader, IKeyReader keyReader, IOneToManyMethodBuilder<T> oneToManyMethodBuilder)
+        public CachedInstanceReader(IInstanceReader<T> instanceReader, IKeyReader keyReader, IOneToManyMethodBuilder<T> oneToManyMethodBuilder, IGenericInstanceReaderFactory instanceReaderFactory)
         {
             this.instanceReader = instanceReader;
             this.keyReader = keyReader;
             this.oneToManyMethodBuilder = oneToManyMethodBuilder;
+            this.instanceReaderFactory = instanceReaderFactory;
         }
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace DbReader.Readers
                 return default(T);
             }
             var method = oneToManyMethodBuilder.CreateMethod(dataRecord, currentPrefix);
-            method?.Invoke(dataRecord, instance);
+            method?.Invoke(dataRecord, instance, instanceReaderFactory);
             return instance;
         }
 

--- a/src/DbReader/Readers/CachedInstanceReader.cs
+++ b/src/DbReader/Readers/CachedInstanceReader.cs
@@ -47,10 +47,10 @@ namespace DbReader.Readers
             var instance = ReadInstance(dataRecord, currentPrefix);
             if (instance == null)
             {
-                return default(T);
+                return default;
             }
             var method = oneToManyMethodBuilder.CreateMethod(dataRecord, currentPrefix);
-            method?.Invoke(dataRecord, instance, instanceReaderFactory);
+            method?.Invoke(instance, dataRecord, instanceReaderFactory);
             return instance;
         }
 

--- a/src/DbReader/Readers/CachedInstanceReader.cs
+++ b/src/DbReader/Readers/CachedInstanceReader.cs
@@ -18,7 +18,7 @@ namespace DbReader.Readers
         private readonly IKeyReader keyReader;
 
         private readonly IOneToManyMethodBuilder<T> oneToManyMethodBuilder;
-        private readonly IGenericInstanceReaderFactory instanceReaderFactory;
+        private readonly IInstanceReaderFactory instanceReaderFactory;
         private readonly ConcurrentDictionary<IStructuralEquatable, T> queryCache = new ConcurrentDictionary<IStructuralEquatable, T>();
 
         /// <summary>
@@ -28,7 +28,8 @@ namespace DbReader.Readers
         /// for reading an instance of <typeparamref name="T"/> from an <see cref="IDataRecord"/>.</param>
         /// <param name="keyReader">An instance of <typeparamref name="T"/>.</param>
         /// <param name="oneToManyMethodBuilder"></param>
-        public CachedInstanceReader(IInstanceReader<T> instanceReader, IKeyReader keyReader, IOneToManyMethodBuilder<T> oneToManyMethodBuilder, IGenericInstanceReaderFactory instanceReaderFactory)
+        /// <param name="instanceReaderFactory">The <see cref="IInstanceReaderFactory"/> that is responsible for resolving <see cref="IInstanceReader{T}"/> instances.</param>
+        public CachedInstanceReader(IInstanceReader<T> instanceReader, IKeyReader keyReader, IOneToManyMethodBuilder<T> oneToManyMethodBuilder, IInstanceReaderFactory instanceReaderFactory)
         {
             this.instanceReader = instanceReader;
             this.keyReader = keyReader;

--- a/src/DbReader/Readers/IInstanceReaderFactory.cs
+++ b/src/DbReader/Readers/IInstanceReaderFactory.cs
@@ -1,19 +1,16 @@
-﻿namespace DbReader.Readers
+namespace DbReader.Readers
 {
-    using System;
-
     /// <summary>
-    /// Represents a class that is capable of 
-    /// producing an <see cref="IInstanceReader{T}"/> based on a given <see cref="Type"/> and prefix.
+    /// Represents a class that is capable of creating an <see cref="IInstanceReader{T}"/> based on the given type.
     /// </summary>
     public interface IInstanceReaderFactory
     {
         /// <summary>
-        /// Gets an <see cref="IInstanceReader{T}"/> for the given <paramref name="type"/> and <paramref name="prefix"/>.
+        /// Gets an <see cref="IInstanceReader{T}"/> based on the type described as <typeparamref name="T"/>
         /// </summary>
-        /// <param name="type">The type for which to get an <see cref="IInstanceReader{T}"/>.</param>
         /// <param name="prefix">The prefix for which to get an <see cref="IInstanceReader{T}"/>.</param>
+        /// <typeparam name="T">The type for which to get an <see cref="IInstanceReader{T}"/>.</typeparam>
         /// <returns></returns>
-        object GetInstanceReader(Type type, string prefix);
+        IInstanceReader<T> GetInstanceReader<T>(string prefix);
     }
 }

--- a/src/DbReader/Readers/InstanceReader.cs
+++ b/src/DbReader/Readers/InstanceReader.cs
@@ -10,15 +10,17 @@
     public class InstanceReader<T> : IInstanceReader<T>
     {
         private readonly IInstanceReaderMethodBuilder<T> instanceReaderMethodBuilder;
-        
+        private readonly IGenericInstanceReaderFactory instanceReaderFactory;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceReader{T}"/> class.
         /// </summary>
-        /// <param name="instanceReaderMethodBuilder">The <see cref="IInstanceReaderMethodBuilder{T}"/> that is responsible 
+        /// <param name="instanceReaderMethodBuilder">The <see cref="IInstanceReaderMethodBuilder{T}"/> that is responsible
         /// for building a method that is capable of reading an instance of <typeparamref name="T"/> from an <see cref="IDataRecord"/>.</param>
-        public InstanceReader(IInstanceReaderMethodBuilder<T> instanceReaderMethodBuilder)
+        public InstanceReader(IInstanceReaderMethodBuilder<T> instanceReaderMethodBuilder, IGenericInstanceReaderFactory instanceReaderFactory)
         {
             this.instanceReaderMethodBuilder = instanceReaderMethodBuilder;
+            this.instanceReaderFactory = instanceReaderFactory;
         }
 
         /// <summary>
@@ -28,9 +30,9 @@
         /// <param name="currentPrefix">The current prefix.</param>
         /// <returns>An instance of <typeparamref name="T"/>.</returns>
         public T Read(IDataRecord dataRecord, string currentPrefix)
-        {                        
+        {
             var method = instanceReaderMethodBuilder.CreateMethod(dataRecord, currentPrefix);
-            return method(dataRecord);
+            return method(dataRecord, instanceReaderFactory);
         }
     }
 }

--- a/src/DbReader/Readers/InstanceReader.cs
+++ b/src/DbReader/Readers/InstanceReader.cs
@@ -10,14 +10,15 @@
     public class InstanceReader<T> : IInstanceReader<T>
     {
         private readonly IInstanceReaderMethodBuilder<T> instanceReaderMethodBuilder;
-        private readonly IGenericInstanceReaderFactory instanceReaderFactory;
+        private readonly IInstanceReaderFactory instanceReaderFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceReader{T}"/> class.
         /// </summary>
         /// <param name="instanceReaderMethodBuilder">The <see cref="IInstanceReaderMethodBuilder{T}"/> that is responsible
         /// for building a method that is capable of reading an instance of <typeparamref name="T"/> from an <see cref="IDataRecord"/>.</param>
-        public InstanceReader(IInstanceReaderMethodBuilder<T> instanceReaderMethodBuilder, IGenericInstanceReaderFactory instanceReaderFactory)
+        /// <param name="instanceReaderFactory">The <see cref="IInstanceReaderFactory"/> that is responsible for resolving <see cref="IInstanceReader{T}"/> instances.</param>
+        public InstanceReader(IInstanceReaderMethodBuilder<T> instanceReaderMethodBuilder, IInstanceReaderFactory instanceReaderFactory)
         {
             this.instanceReaderMethodBuilder = instanceReaderMethodBuilder;
             this.instanceReaderFactory = instanceReaderFactory;

--- a/src/DbReader/Readers/InstanceReaderFactory.cs
+++ b/src/DbReader/Readers/InstanceReaderFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using DbReader.LightInject;
 
 namespace DbReader.Readers
 {
@@ -44,15 +45,17 @@ namespace DbReader.Readers
         private readonly ConcurrentDictionary<Tuple<Type, string>, object> readers = new ConcurrentDictionary<Tuple<Type, string>, object>();
 
         private readonly Func<Type, object> createReader;
+        private readonly IServiceFactory serviceFactory;
 
-        public GenericInstanceReaderFactory(Func<Type, object> createReader)
+        internal GenericInstanceReaderFactory(IServiceFactory serviceFactory)
         {
-            this.createReader = createReader;
+            this.serviceFactory = serviceFactory;
         }
 
         public IInstanceReader<T> GetInstanceReader<T>(string prefix)
         {
-            return (IInstanceReader<T>)createReader(typeof(IInstanceReader<>).MakeGenericType(typeof(T)));
+            return serviceFactory.GetInstance<IInstanceReader<T>>();
+            //return (IInstanceReader<T>)createReader(typeof(IInstanceReader<>).MakeGenericType(typeof(T)));
             //return (IInstanceReader<T>)readers.GetOrAdd(Tuple.Create(typeof(T), prefix), t => createReader(typeof(IInstanceReader<>).MakeGenericType(t.Item1)));
         }
     }

--- a/src/DbReader/Readers/InstanceReaderFactory.cs
+++ b/src/DbReader/Readers/InstanceReaderFactory.cs
@@ -4,7 +4,7 @@ using System.Collections.Concurrent;
 namespace DbReader.Readers
 {
     /// <summary>
-    /// A class that is capable of 
+    /// A class that is capable of
     /// producing an <see cref="IInstanceReader{T}"/> based on a given <see cref="Type"/> and prefix.
     /// </summary>
     public class InstanceReaderFactory : IInstanceReaderFactory
@@ -31,6 +31,29 @@ namespace DbReader.Readers
         public object GetInstanceReader(Type type, string prefix)
         {
             return readers.GetOrAdd(Tuple.Create(type, prefix), t => createReader(t.Item1));
+        }
+    }
+
+    public interface IGenericInstanceReaderFactory
+    {
+        IInstanceReader<T> GetInstanceReader<T>(string prefix);
+    }
+
+    public class GenericInstanceReaderFactory : IGenericInstanceReaderFactory
+    {
+        private readonly ConcurrentDictionary<Tuple<Type, string>, object> readers = new ConcurrentDictionary<Tuple<Type, string>, object>();
+
+        private readonly Func<Type, object> createReader;
+
+        public GenericInstanceReaderFactory(Func<Type, object> createReader)
+        {
+            this.createReader = createReader;
+        }
+
+        public IInstanceReader<T> GetInstanceReader<T>(string prefix)
+        {
+            return (IInstanceReader<T>)createReader(typeof(IInstanceReader<>).MakeGenericType(typeof(T)));
+            //return (IInstanceReader<T>)readers.GetOrAdd(Tuple.Create(typeof(T), prefix), t => createReader(typeof(IInstanceReader<>).MakeGenericType(t.Item1)));
         }
     }
 }


### PR DESCRIPTION
This PR fixes a serious bug in `OneToManyMethodBuilder` and `ManyToOneMethodBuilder` where we closed around the `IInstanceReader` causing the "old" reader to be used in any subsequent read operations.

