### PR TITLE
Ensure convert-functions are invoked.

### DIFF
--- a/src/DbReader.Tests/ArgumentParserMethodBuilderTests.cs
+++ b/src/DbReader.Tests/ArgumentParserMethodBuilderTests.cs
@@ -53,15 +53,10 @@ namespace DbReader.Tests
         [Fact]
         public void ShouldHandleNullableEnumWithoutConverterFunction()
         {
-            DbReaderOptions.WhenPassing<int>().Use((parameter, value) =>
-            {
-
-            });
-
             var args = new { Status = new EnumWithoutConverterFunction?(EnumWithoutConverterFunction.Value2) };
             var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
             var result = method("@Status", args, () => new TestDataParameter());
-            result.Parameters[0].Value.ShouldBe(EnumWithoutConverterFunction.Value2);
+            result.Parameters[0].Value.ShouldBe(2);
         }
 
 

--- a/src/DbReader.Tests/ArgumentParserMethodBuilderTests.cs
+++ b/src/DbReader.Tests/ArgumentParserMethodBuilderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using DbReader.Construction;
 using Moq;
 using Shouldly;
@@ -21,6 +22,95 @@ namespace DbReader.Tests
         }
 
 
+        [Fact]
+        public void ShouldHandleEnumWithoutConverterFunction()
+        {
+            var args = new { Status = EnumWithoutConverterFunction.Value2 };
+            var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
+            var result = method("@Status", args, () => new TestDataParameter());
+            result.Parameters[0].Value.ShouldBe(2);
+        }
+
+        [Fact]
+        public void ShouldHandleEnumWithConverterFunction()
+        {
+            DbReaderOptions.WhenPassing<EnumWithConverterFunction>().Use((parameter, value) => parameter.Value = (int)EnumWithConverterFunction.Value3);
+            var args = new { Status = EnumWithConverterFunction.Value2 };
+            var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
+            var result = method("@Status", args, () => new TestDataParameter());
+            result.Parameters[0].Value.ShouldBe(3);
+        }
+
+        [Fact]
+        public void ShouldHandleNullableEnumWithoutConverterFunctionPassingNull()
+        {
+            var args = new { Status = new EnumWithoutConverterFunction?() };
+            var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
+            var result = method("@Status", args, () => new TestDataParameter());
+            result.Parameters[0].Value.ShouldBe(DBNull.Value);
+        }
+
+        [Fact]
+        public void ShouldHandleNullableEnumWithoutConverterFunction()
+        {
+            DbReaderOptions.WhenPassing<int>().Use((parameter, value) =>
+            {
+
+            });
+
+            var args = new { Status = new EnumWithoutConverterFunction?(EnumWithoutConverterFunction.Value2) };
+            var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
+            var result = method("@Status", args, () => new TestDataParameter());
+            result.Parameters[0].Value.ShouldBe(EnumWithoutConverterFunction.Value2);
+        }
+
+
+        [Fact]
+        public void ShouldHandleNullableEnum()
+        {
+            // Nullable<int> nullableInt = 10;
+
+            // var r = nullableInt.GetType();
+
+            // TestMethod(nullableInt);
+
+            var args = new { Status = new Nullable<DbType>(DbType.Currency) };
+            //DbReaderOptions.WhenPassing<DbType>().Use((p, v) => p.Value = 1);
+            var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
+            var result = method("@Status", args, () => new TestDataParameter());
+        }
+
+        [Fact]
+        public void ShouldHandleNullableInt()
+        {
+            var args = new { Status = new Nullable<int>(42) };
+            //DbReaderOptions.WhenPassing<DbType?>().Use((p, v) => p.Value = 1);
+            var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
+            var result = method("@Status", args, () => new TestDataParameter());
+        }
+
+        public class TestDataParameter : IDataParameter
+        {
+            private object _value;
+
+            public DbType DbType { get; set; }
+            public ParameterDirection Direction { get; set; }
+
+            public bool IsNullable => true;
+
+            public string ParameterName { get; set; }
+            public string SourceColumn { get; set; }
+            public DataRowVersion SourceVersion { get; set; }
+            public object Value
+            {
+                get => _value; set
+                {
+                    _value = value;
+                }
+            }
+        }
+
+
         public class ThrowingDataParameter : IDataParameter
         {
             public DbType DbType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
@@ -33,5 +123,19 @@ namespace DbReader.Tests
             public DataRowVersion SourceVersion { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public object Value { get => throw new NotImplementedException(); set => throw new ArgumentException(); }
         }
+    }
+
+    public enum EnumWithoutConverterFunction
+    {
+        Value1 = 1,
+        Value2 = 2,
+        Value3 = 3
+    }
+
+    public enum EnumWithConverterFunction
+    {
+        Value1 = 1,
+        Value2 = 2,
+        Value3 = 3
     }
 }

--- a/src/DbReader.Tests/ArgumentParserMethodBuilderTests.cs
+++ b/src/DbReader.Tests/ArgumentParserMethodBuilderTests.cs
@@ -25,7 +25,7 @@ namespace DbReader.Tests
         [Fact]
         public void ShouldHandleEnumWithoutConverterFunction()
         {
-            var args = new { Status = EnumWithoutConverterFunction.Value2 };
+            var args = new { Status = EnumParameterWithoutConverterFunction.Value2 };
             var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
             var result = method("@Status", args, () => new TestDataParameter());
             result.Parameters[0].Value.ShouldBe(2);
@@ -34,8 +34,8 @@ namespace DbReader.Tests
         [Fact]
         public void ShouldHandleEnumWithConverterFunction()
         {
-            DbReaderOptions.WhenPassing<EnumWithConverterFunction>().Use((parameter, value) => parameter.Value = (int)EnumWithConverterFunction.Value3);
-            var args = new { Status = EnumWithConverterFunction.Value2 };
+            DbReaderOptions.WhenPassing<EnumParameterWithConverterFunction>().Use((parameter, value) => parameter.Value = (int)EnumParameterWithConverterFunction.Value3);
+            var args = new { Status = EnumParameterWithConverterFunction.Value2 };
             var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
             var result = method("@Status", args, () => new TestDataParameter());
             result.Parameters[0].Value.ShouldBe(3);
@@ -44,7 +44,7 @@ namespace DbReader.Tests
         [Fact]
         public void ShouldHandleNullableEnumWithoutConverterFunctionPassingNull()
         {
-            var args = new { Status = new EnumWithoutConverterFunction?() };
+            var args = new { Status = new EnumParameterWithoutConverterFunction?() };
             var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
             var result = method("@Status", args, () => new TestDataParameter());
             result.Parameters[0].Value.ShouldBe(DBNull.Value);
@@ -53,7 +53,7 @@ namespace DbReader.Tests
         [Fact]
         public void ShouldHandleNullableEnumWithoutConverterFunction()
         {
-            var args = new { Status = new EnumWithoutConverterFunction?(EnumWithoutConverterFunction.Value2) };
+            var args = new { Status = new EnumParameterWithoutConverterFunction?(EnumParameterWithoutConverterFunction.Value2) };
             var method = argumentParserMethodBuilder.CreateMethod("@Status", args.GetType(), Array.Empty<IDataParameter>());
             var result = method("@Status", args, () => new TestDataParameter());
             result.Parameters[0].Value.ShouldBe(2);
@@ -118,19 +118,20 @@ namespace DbReader.Tests
             public DataRowVersion SourceVersion { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
             public object Value { get => throw new NotImplementedException(); set => throw new ArgumentException(); }
         }
+        public enum EnumParameterWithoutConverterFunction
+        {
+            Value1 = 1,
+            Value2 = 2,
+            Value3 = 3
+        }
+
+        public enum EnumParameterWithConverterFunction
+        {
+            Value1 = 1,
+            Value2 = 2,
+            Value3 = 3
+        }
     }
 
-    public enum EnumWithoutConverterFunction
-    {
-        Value1 = 1,
-        Value2 = 2,
-        Value3 = 3
-    }
 
-    public enum EnumWithConverterFunction
-    {
-        Value1 = 1,
-        Value2 = 2,
-        Value3 = 3
-    }
 }

--- a/src/DbReader.Tests/DbReader.Tests.csproj
+++ b/src/DbReader.Tests/DbReader.Tests.csproj
@@ -21,7 +21,7 @@
     </PackageReference>
     <PackageReference Include="moq" Version="4.18.2" />
     <PackageReference Include="shouldly" Version="4.1.0" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.116" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />

--- a/src/DbReader.Tests/InstanceReaderTests.cs
+++ b/src/DbReader.Tests/InstanceReaderTests.cs
@@ -216,6 +216,22 @@
             instance.Property.ShouldBe(SampleEnum.One);
         }
 
+        [Fact]
+        public void ShouldReadNullableEnum()
+        {
+            //DbReaderOptions.WhenReading<SampleEnum?>().Use((dr, ordinal) => (SampleEnum)dr.GetInt32(ordinal));
+            var dataRecord = new { Id = 1, Property = 1 }.ToDataRecord();
+            var instance = GetReader<ClassWithProperty<SampleEnum?>>().Read(dataRecord, string.Empty);
+            instance.Property.ShouldBe(SampleEnum.One);
+        }
+
+        [Fact]
+        public void ShouldReadNullableEnumWithNullValue()
+        {
+            var dataRecord = new { Id = 1, Property = DBNull.Value }.ToDataRecord();
+            var instance = GetReader<ClassWithProperty<SampleEnum?>>().Read(dataRecord, string.Empty);
+            instance.Property.ShouldBeNull();
+        }
 
         [Fact]
         public void ShouldReadCustomValueType()

--- a/src/DbReader.Tests/InstanceReaderTests.cs
+++ b/src/DbReader.Tests/InstanceReaderTests.cs
@@ -312,6 +312,17 @@
 
 
         [Fact]
+        public void ShouldUseConverterFunctionEvenWhenEnumHasIncompatibleUnderlyingType2()
+        {
+            DbReaderOptions.WhenReading<Int32Enum>().Use((dr, i) => (Int32Enum)dr.GetInt64(i));
+            var dataRecord = new { Id = 1, Property = new Int32Enum?() }.ToDataRecord();
+            var reader = GetReader<ClassWithProperty<Int32Enum>>();
+            var instance = reader.Read(dataRecord, string.Empty);
+            instance.Property.ShouldBe(Int32Enum.One);
+        }
+
+
+        [Fact]
         public void ShouldHandleManyToOneWithoutAnyMatchingColumns()
         {
             var dataRecord = new { Id = 1 }.ToDataRecord();

--- a/src/DbReader.Tests/InstanceReaderTests.cs
+++ b/src/DbReader.Tests/InstanceReaderTests.cs
@@ -310,18 +310,6 @@
             instance.Property.ShouldBe(Int32Enum.One);
         }
 
-
-        [Fact]
-        public void ShouldUseConverterFunctionEvenWhenEnumHasIncompatibleUnderlyingType2()
-        {
-            DbReaderOptions.WhenReading<Int32Enum>().Use((dr, i) => (Int32Enum)dr.GetInt64(i));
-            var dataRecord = new { Id = 1, Property = new Int32Enum?() }.ToDataRecord();
-            var reader = GetReader<ClassWithProperty<Int32Enum>>();
-            var instance = reader.Read(dataRecord, string.Empty);
-            instance.Property.ShouldBe(Int32Enum.One);
-        }
-
-
         [Fact]
         public void ShouldHandleManyToOneWithoutAnyMatchingColumns()
         {

--- a/src/DbReader.Tests/InstanceReaderTests.cs
+++ b/src/DbReader.Tests/InstanceReaderTests.cs
@@ -219,7 +219,6 @@
         [Fact]
         public void ShouldReadNullableEnum()
         {
-            //DbReaderOptions.WhenReading<SampleEnum?>().Use((dr, ordinal) => (SampleEnum)dr.GetInt32(ordinal));
             var dataRecord = new { Id = 1, Property = 1 }.ToDataRecord();
             var instance = GetReader<ClassWithProperty<SampleEnum?>>().Read(dataRecord, string.Empty);
             instance.Property.ShouldBe(SampleEnum.One);
@@ -232,6 +231,38 @@
             var instance = GetReader<ClassWithProperty<SampleEnum?>>().Read(dataRecord, string.Empty);
             instance.Property.ShouldBeNull();
         }
+
+        [Fact]
+        public void ShouldReadNullableEnumWithConverterFunction()
+        {
+            var dataRecord = new { Id = 1, Property = 2 }.ToDataRecord();
+            bool wasCalled = false;
+            DbReaderOptions.WhenReading<EnumWithConverterFunction>().Use((dataRecord, ordinal) =>
+            {
+                wasCalled = true;
+                return (EnumWithConverterFunction)dataRecord.GetInt32(ordinal);
+            });
+            var instance = GetReader<ClassWithProperty<EnumWithConverterFunction?>>().Read(dataRecord, string.Empty);
+            instance.Property.ShouldBe(EnumWithConverterFunction.Value2);
+            wasCalled.ShouldBe(true);
+        }
+
+
+        [Fact]
+        public void ShouldReadNullableEnumWithConverterFunctionForIntegralType()
+        {
+            var dataRecord = new { Id = 1, Property = 2 }.ToDataRecord();
+            bool wasCalled = false;
+            DbReaderOptions.WhenReading<ushort>().Use((dataRecord, ordinal) =>
+            {
+                wasCalled = true;
+                return (ushort)dataRecord.GetInt32(ordinal);
+            });
+            var instance = GetReader<ClassWithProperty<EnumWithoutConverterFunctionForIntegralType>>().Read(dataRecord, string.Empty);
+            instance.Property.ShouldBe(EnumWithoutConverterFunctionForIntegralType.Value2);
+            wasCalled.ShouldBe(true);
+        }
+
 
         [Fact]
         public void ShouldReadCustomValueType()
@@ -368,6 +399,21 @@
             var result = reader.Read(dataRecord, string.Empty);
             result.Children.ShouldBeEmpty();
         }
+
+        public enum EnumWithoutConverterFunctionForIntegralType : ushort
+        {
+            Value1 = 1,
+            Value2 = 2,
+            Value3 = 3
+        }
+
+        public enum EnumWithConverterFunction
+        {
+            Value1 = 1,
+            Value2 = 2,
+            Value3 = 3
+        }
+
 
         public enum Int32Enum
         {

--- a/src/DbReader/ArgumentProcessor.cs
+++ b/src/DbReader/ArgumentProcessor.cs
@@ -20,10 +20,40 @@ namespace DbReader
         {
             ConvertMethod = typeof(ArgumentProcessor).GetTypeInfo().DeclaredMethods
                 .Single(m => m.Name == "Process");
-            ProcessDelegates.TryAdd(typeof(int), (parameter, value) =>
+            ProcessDelegates.TryAdd(typeof(int), (parameter, value) => AssignParameterValue(parameter, (int)value));
+            ProcessDelegates.TryAdd(typeof(uint), (parameter, value) => AssignParameterValue(parameter, (uint)value));
+            ProcessDelegates.TryAdd(typeof(long), (parameter, value) => AssignParameterValue(parameter, (long)value));
+            ProcessDelegates.TryAdd(typeof(ulong), (parameter, value) => AssignParameterValue(parameter, (ulong)value));
+            ProcessDelegates.TryAdd(typeof(string), (parameter, value) => AssignParameterValue(parameter, (string)value));
+            ProcessDelegates.TryAdd(typeof(DateTime), (parameter, value) => AssignParameterValue(parameter, (DateTime)value));
+            ProcessDelegates.TryAdd(typeof(Guid), (parameter, value) => AssignParameterValue(parameter, (Guid)value));
+            ProcessDelegates.TryAdd(typeof(decimal), (parameter, value) => AssignParameterValue(parameter, (decimal)value));
+            ProcessDelegates.TryAdd(typeof(byte[]), (parameter, value) => AssignParameterValue(parameter, (byte[])value));
+            ProcessDelegates.TryAdd(typeof(char[]), (parameter, value) => AssignParameterValue(parameter, (char[])value));
+            ProcessDelegates.TryAdd(typeof(sbyte), (parameter, value) => AssignParameterValue(parameter, (sbyte)value));
+            ProcessDelegates.TryAdd(typeof(byte), (parameter, value) => AssignParameterValue(parameter, (byte)value));
+            ProcessDelegates.TryAdd(typeof(short), (parameter, value) => AssignParameterValue(parameter, (short)value));
+            ProcessDelegates.TryAdd(typeof(ushort), (parameter, value) => AssignParameterValue(parameter, (ushort)value));
+            ProcessDelegates.TryAdd(typeof(ushort), (parameter, value) => AssignParameterValue(parameter, (ushort)value));            
+        }
+
+
+        //Extension method?
+        private static void AssignParameterValue<T>(IDataParameter dataParameter, T value)
+        {
+            try
             {
-                parameter.Value = (int)value;
-            });
+                dataParameter.Value = ToDbNullIfNull(value);
+            }
+            catch
+            {
+                throw new ArgumentOutOfRangeException(dataParameter.ParameterName, value, ErrorMessages.InvalidParameterValue.FormatWith(dataParameter.ParameterName, value, value == null ? "null" : value.GetType().Name));
+            }
+        }
+
+        private static object ToDbNullIfNull(object value)
+        {
+            return value ?? DBNull.Value;
         }
 
         public static void RegisterProcessDelegate<TArgument>(Action<IDataParameter, TArgument> convertFunction)

--- a/src/DbReader/Construction/ReaderMethodBuilder.cs
+++ b/src/DbReader/Construction/ReaderMethodBuilder.cs
@@ -12,8 +12,8 @@ namespace DbReader.Construction
     /// implementations.
     /// </summary>
     /// <typeparam name="T">The type of object to be created.</typeparam> 
-    public abstract class ReaderMethodBuilder<T> : IReaderMethodBuilder<T> 
-    {        
+    public abstract class ReaderMethodBuilder<T> : IReaderMethodBuilder<T>
+    {
         private readonly IMethodSkeletonFactory methodSkeletonFactory;
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace DbReader.Construction
             MethodSelector = methodSelector;
             this.methodSkeletonFactory = methodSkeletonFactory;
         }
-        
+
         /// <summary>
         /// Gets the <see cref="IMethodSelector"/> that is responsible for selecting the <see cref="IDataRecord"/> 
         /// get method that corresponds to the property type.
@@ -93,7 +93,7 @@ namespace DbReader.Construction
         /// <param name="targetType">The <see cref="Type"/> of the target <see cref="PropertyInfo"/> or <see cref="ParameterInfo"/>.</param>
         protected void EmitGetValue(ILGenerator il, int index, MethodInfo getMethod, Type targetType)
         {
-            if (targetType.IsNullable())
+            if (targetType.IsNullable() && !getMethod.ReturnType.IsNullable())
             {
                 EmitGetNullableValue(il, index, getMethod, targetType);
             }
@@ -177,7 +177,7 @@ namespace DbReader.Construction
         {
             return (Func<IDataRecord, int[], T>)methodSkeleton.CreateDelegate(typeof(Func<IDataRecord, int[], T>));
         }
-       
+
         private static void LoadDataRecord(ILGenerator il)
         {
             il.Emit(OpCodes.Ldarg_0);

--- a/src/DbReader/DataReaderExtensions.cs
+++ b/src/DbReader/DataReaderExtensions.cs
@@ -5,8 +5,8 @@
     using System.Data;
     using System.Runtime.CompilerServices;
     using Construction;
-    using LightInject;
     using Extensions;
+    using LightInject;
     using Readers;
     using Selectors;
 

--- a/src/DbReader/Extensions/TypeReflectionExtensions.cs
+++ b/src/DbReader/Extensions/TypeReflectionExtensions.cs
@@ -80,7 +80,6 @@ namespace DbReader.Extensions
         /// <returns><b>true</b> if the <paramref name="type"/> is a "simple" type, otherwise <b>false</b></returns>
         public static bool IsSimpleType(this Type type)
         {
-            type = type.GetUnderlyingType();
             return type.GetTypeInfo().IsPrimitive || SimpleTypes.Contains(type) || ValueConverter.CanConvert(type) || ArgumentProcessor.CanProcess(type);
         }
 

--- a/src/DbReader/Extensions/TypeReflectionExtensions.cs
+++ b/src/DbReader/Extensions/TypeReflectionExtensions.cs
@@ -80,6 +80,7 @@ namespace DbReader.Extensions
         /// <returns><b>true</b> if the <paramref name="type"/> is a "simple" type, otherwise <b>false</b></returns>
         public static bool IsSimpleType(this Type type)
         {
+            type = type.GetUnderlyingType();
             return type.GetTypeInfo().IsPrimitive || SimpleTypes.Contains(type) || ValueConverter.CanConvert(type) || ArgumentProcessor.CanProcess(type);
         }
 

--- a/src/DbReader/Selectors/MethodSelector.cs
+++ b/src/DbReader/Selectors/MethodSelector.cs
@@ -31,6 +31,13 @@
                 return ValueConverter.GetConvertMethod(type);
             }
 
+            type = type.GetUnderlyingType();
+
+            if (ValueConverter.CanConvert(type))
+            {
+                return ValueConverter.GetConvertMethod(type);
+            }
+
             if (type == typeof(bool))
             {
                 return typeof(IDataRecord).GetTypeInfo().GetMethod("GetBoolean");

--- a/src/DbReader/Selectors/OneToManyPropertyValidator.cs
+++ b/src/DbReader/Selectors/OneToManyPropertyValidator.cs
@@ -16,7 +16,7 @@
     {
         private readonly IPropertySelector oneToManyPropertySelector;
 
-        private static readonly Type[] ValidCollectionTypes = {typeof(IEnumerable<>), typeof(ICollection<>), typeof(Collection<>)};
+        private static readonly Type[] ValidCollectionTypes = { typeof(IEnumerable<>), typeof(ICollection<>), typeof(Collection<>) };
         private static readonly Lazy<string> ValidCollectionTypesMessage;
 
         static OneToManyPropertyValidator()
@@ -87,10 +87,10 @@
             var openGenericTypeDefinition = propertyType.GetGenericTypeDefinition();
             return ValidCollectionTypes.Contains(openGenericTypeDefinition);
         }
-      
+
         private static bool IsValidProjectionType(Type propertyType)
         {
             return !propertyType.GetTypeInfo().GenericTypeArguments[0].IsSimpleType();
-        }       
+        }
     }
 }

--- a/src/DbReader/TypeEvaluator.cs
+++ b/src/DbReader/TypeEvaluator.cs
@@ -27,7 +27,7 @@
         private static bool EvaluateType()
         {
             PropertyInfo[] properties = typeof(T).GetProperties();
-            return properties.Any(p => !p.PropertyType.IsSimpleType());            
+            return properties.Any(p => !p.PropertyType.IsSimpleType());
         }
     }
 }


### PR DESCRIPTION
This PR ensures that convert funstions (WhenPassing and WhenReader) are called even if not needed. 
Also fixed "CLR detected an Invalid Program" when using `WhenPassing` for a nullable type.